### PR TITLE
Fix/fixes on pr8

### DIFF
--- a/openpose_editor_nodes.py
+++ b/openpose_editor_nodes.py
@@ -36,22 +36,26 @@ class OpenposeEditorNode:
                 "hands_scale": ("FLOAT", {
                     "default": 1.0,
                     "min": 0.0,
-                    "max": 10.0
+                    "max": 10.0,
+                    "step": 0.05
                 }),
                 "body_scale": ("FLOAT", {
                     "default": 1.0,
                     "min": 0.0,
-                    "max": 10.0
+                    "max": 10.0,
+                    "step": 0.05
                 }),
                 "head_scale": ("FLOAT", {
                     "default": 1.0,
                     "min": 0.0,
-                    "max": 10.0
+                    "max": 10.0,
+                    "step": 0.05
                 }),
                 "overall_scale": ("FLOAT", {
                     "default": 1.0,
                     "min": 0.0,
-                    "max": 10.0
+                    "max": 10.0,
+                    "step": 0.05
                 }),
                 "POSE_JSON": ("STRING", {"multiline": True}),
                 "POSE_KEYPOINT": ("POSE_KEYPOINT",{"default": None}),


### PR DESCRIPTION
## Fix: OpenPose Editor Node Scaling & Multi-Pose Support

### Overview

This is an amazing idea and I am very excited for it! I ran in to some of the same bugs as denoted in the PR, and a few others. This PR aims to address some of those

### What’s Fixed

- Body and overall scaling now work correctly with normalized coordinates, so poses scale as expected.
- Face and hand offsets are calculated per figure, which helps keep faces and hands properly aligned with their respective bodies in multi-pose scenes.
- All scaling operations now consistently use normalized coordinate space ([0, 1]), improving reliability across different image sizes.
- The code now handles missing or `None` hand/face data gracefully, preventing errors when some figures lack these keypoints.

### What's Otherwise Modified
- Set the step size of the scaling for more granular control, which helps with smaller resolution images.

### Notes

- These changes should resolve issues with black images and overlapping faces when using scaling, both for single and multiple poses.
- If you notice any edge cases or regressions, please let me know—I'm happy to help iterate further!
- 
Thank you for reviewing and considering these improvements!